### PR TITLE
Fixed doc for "update"

### DIFF
--- a/docs/api/ReactWrapper/update.md
+++ b/docs/api/ReactWrapper/update.md
@@ -12,8 +12,6 @@ NOTE: this does not force a re-render. Use `wrapper.setProps({})` to force a re-
 
 `ReactWrapper`: Returns itself.
 
-
-
 #### Example
 
 ```jsx
@@ -38,12 +36,12 @@ class UpdateEnzyme extends React.Component {
 }
 ```
 ```jsx
-const wrapper = mount(<UpdateEnzyme />);
+let wrapper = mount(<UpdateEnzyme />);
 expect(wrapper.find('button.increment').text()).to.equal('0');
 wrapper.instance().increment();
 
 // Update Enzyme's view of output
-wrapper.update();
+wrapper = wrapper.update();
 
 expect(wrapper.find('button.increment').text()).to.equal('1');
 ```


### PR DESCRIPTION
cf : https://github.com/enzymejs/enzyme/issues/1153#issuecomment-394951184

Not entirely sure this is the canonical way to use it, and it seems some people managed to use `update` without reassignating `wrapper`, although I can't do it myself, which is incomprehensible to me. I'll let whoever is competent determine the truth of that.

And if my suggestion is not correct, please note that the issue linked above is still a problem as of 3.11.0. Also I am using @wojtekmaj/enzyme-adapter-react-17 because the adapter 16 doesn't work for me.